### PR TITLE
Wider UI and MonoSpace Text Boxes

### DIFF
--- a/chrome/content/randomsigEdit.xul
+++ b/chrome/content/randomsigEdit.xul
@@ -19,7 +19,7 @@
 	<stringbundle id="randomsig-stringbundle" src="chrome://randomsig/locale/randomsig.properties"/>
 </stringbundleset>
 
-<vbox flex="1" width="400">
+<vbox flex="1" width="700">
 	<groupbox>
 		<caption align="center">
 			<label value="&randomsig.editnew-source;"/>
@@ -92,7 +92,7 @@
 						<description>
 							&randomsig.editnew-prefix-desc;
 						</description>
-						<textbox id="randomsig-edit-prefix" multiline="true" rows="4" flex="1"/>
+						<textbox id="randomsig-edit-prefix" multiline="true" rows="4" flex="1" class="monospace"/>
 					</vbox>
 				</tabpanel>
 				<tabpanel>
@@ -100,7 +100,7 @@
 						<description>
 							&randomsig.editnew-suffix-desc;
 						</description>
-						<textbox id="randomsig-edit-suffix" multiline="true" rows="4" flex="1"/>
+						<textbox id="randomsig-edit-suffix" multiline="true" rows="4" flex="1" class="monospace"/>
 					</vbox>
 				</tabpanel>
 			</tabpanels>

--- a/chrome/content/randomsigNew.xul
+++ b/chrome/content/randomsigNew.xul
@@ -18,7 +18,7 @@
 	<stringbundle id="randomsig-stringbundle" src="chrome://randomsig/locale/randomsig.properties"/>
 </stringbundleset>
 
-<vbox flex="1" width="400">
+<vbox flex="1" width="700">
 	<groupbox>
 		<caption align="center">
 			<label value="&randomsig.editnew-source;"/>
@@ -91,7 +91,7 @@
 						<description>
 							&randomsig.editnew-prefix-desc;
 						</description>
-						<textbox id="randomsig-new-prefix" multiline="true" rows="4" flex="1"/>
+						<textbox id="randomsig-new-prefix" multiline="true" rows="4" flex="1" class="monospace"/>
 					</vbox>
 				</tabpanel>
 				<tabpanel>
@@ -99,7 +99,7 @@
 						<description>
 							&randomsig.editnew-suffix-desc;
 						</description>
-						<textbox id="randomsig-new-suffix" multiline="true" rows="4" flex="1"/>
+						<textbox id="randomsig-new-suffix" multiline="true" rows="4" flex="1" class="monospace"/>
 					</vbox>
 				</tabpanel>
 			</tabpanels>

--- a/chrome/content/randomsigOptions.xul
+++ b/chrome/content/randomsigOptions.xul
@@ -17,7 +17,7 @@
 	<stringbundle id="randomsig-stringbundle" src="chrome://randomsig/locale/randomsig.properties"/>
 </stringbundleset>
 
-<vbox flex="1" width="600">
+<vbox flex="1" width="800">
 	<label value="&randomsig.options-title;"/>
 	<grid flex="1">
 		<columns>


### PR DESCRIPTION
Made the windows in the UI wider - now that everyone has a decently wide screen there is no need to limit the UI to 400px wide. I also needed this to make the PREFIX/SUFFIX text-boxes wider to accommodate my signature and to accommodate the other change in the Pull : to make the text in PREFIX/SUFFIX use monospace font, since signatures are in monospace font in TB. 